### PR TITLE
サブメニュー状態管理の修正

### DIFF
--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -19,6 +19,13 @@ export class MenuScene extends Phaser.Scene {
     this.playerData = DEFAULT_PLAYER_DATA;
   }
 
+  init(): void {
+    // シーン初期化時に状態をリセット
+    this.subMenuActive = false;
+    this.currentSubMenu = null;
+    console.log("MenuScene initialized, states reset");
+  }
+
   preload(): void {
     // プレイヤーデータのロード（将来的にはセーブデータから）
     // 現在はデフォルト値を使用
@@ -238,7 +245,7 @@ export class MenuScene extends Phaser.Scene {
   
   // ステージ選択メニューを開く
   private openStageSelect(): void {
-    console.log("Opening stage select menu");
+    console.log("Opening stage select menu, subMenuActive state:", this.subMenuActive);
     if (this.subMenuActive) {
       console.log("Sub menu already active, not opening new one");
       return;
@@ -348,7 +355,7 @@ export class MenuScene extends Phaser.Scene {
   
   // アイテムメニューを開く
   private openItemMenu(): void {
-    console.log("Opening item menu");
+    console.log("Opening item menu, subMenuActive state:", this.subMenuActive);
     if (this.subMenuActive) {
       console.log("Sub menu already active, not opening new one");
       return;
@@ -459,7 +466,7 @@ export class MenuScene extends Phaser.Scene {
   
   // 装備メニューを開く
   private openEquipmentMenu(): void {
-    console.log("Opening equipment menu");
+    console.log("Opening equipment menu, subMenuActive state:", this.subMenuActive);
     if (this.subMenuActive) {
       console.log("Sub menu already active, not opening new one");
       return;
@@ -536,7 +543,7 @@ export class MenuScene extends Phaser.Scene {
   
   // ステータス詳細メニューを開く
   private openStatusMenu(): void {
-    console.log("Opening status menu");
+    console.log("Opening status menu, subMenuActive state:", this.subMenuActive);
     if (this.subMenuActive) {
       console.log("Sub menu already active, not opening new one");
       return;


### PR DESCRIPTION
## サブメニュー状態管理の修正

### 問題点
- メニューからバトルシーンに遷移し、バトル終了後にメニュー画面に戻ってきた際に、サブメニューが開けなくなる問題を修正
- コンソールログには `Sub menu already active, not opening new one` というメッセージが表示され、シーン遷移後も `subMenuActive` フラグが `true` のままになっていることが判明

### 修正内容
- `MenuScene` クラスに `init()` メソッドを追加
- シーンがロードされるたびに `subMenuActive` と `currentSubMenu` の状態を正しくリセット
- ログ出力を追加して問題の追跡を容易に

### テスト実施内容
1. メニュー画面からサブメニューが開くことを確認
2. 「バトル開始」→戦闘シーン→リザルト画面→メニュー画面と遷移
3. メニュー画面に戻った後も問題なくサブメニューが開くことを確認

この修正により、シーンの再初期化時に状態がリセットされ、戦闘後もメニューが正常に機能するようになりました。