### PR TITLE
エネミーシステムのTypeScriptエラー修正

### DIFF
--- a/src/objects/EnemyUnit.ts
+++ b/src/objects/EnemyUnit.ts
@@ -54,15 +54,12 @@ export class EnemyUnit extends Unit {
    */
   constructor(config: EnemyUnitConfig) {
     // 初期値を計算
-    const calculatedStats = EnemyUnit.calculateStats(
-      config.level,
-      {
-        maxHealth: 50,
-        attack: 8,
-        defense: 4,
-        speed: 1.5
-      }
-    );
+    const calculatedStats = EnemyUnit.calculateStats(config.level, {
+      maxHealth: 50,
+      attack: 8,
+      defense: 4,
+      speed: 1.5,
+    });
 
     // 優先的にカスタムステータスを使用し、ない場合は計算済みのステータスを使用
     const maxHealth = config.customStats?.maxHealth || calculatedStats.maxHealth;

--- a/src/objects/EnemyUnit.ts
+++ b/src/objects/EnemyUnit.ts
@@ -38,7 +38,7 @@ export interface DropItem {
  */
 export class EnemyUnit extends Unit {
   // エネミーの基本情報
-  protected level: number;
+  protected level: number = 1;
   protected baseMaxHealth: number = 50;
   protected baseAttack: number = 8;
   protected baseDefense: number = 4;
@@ -48,28 +48,29 @@ export class EnemyUnit extends Unit {
   // ドロップアイテム
   protected possibleDrops: DropItem[] = [];
 
-  // グラフィックス要素
-  protected unitCircle: Phaser.GameObjects.Graphics;
-
   /**
    * コンストラクタ
    * @param config エネミー設定
    */
   constructor(config: EnemyUnitConfig) {
-    // 基本ステータスの初期化
-    this.initializeBaseStats();
+    // 初期値を計算
+    const calculatedStats = EnemyUnit.calculateStats(
+      config.level,
+      {
+        maxHealth: 50,
+        attack: 8,
+        defense: 4,
+        speed: 1.5
+      }
+    );
 
-    // レベルに応じてステータスを計算
-    const { maxHealth, attack, defense, speed } =
-      config.customStats ||
-      EnemyUnit.calculateStats(config.level, {
-        maxHealth: this.baseMaxHealth,
-        attack: this.baseAttack,
-        defense: this.baseDefense,
-        speed: this.baseSpeed,
-      });
+    // 優先的にカスタムステータスを使用し、ない場合は計算済みのステータスを使用
+    const maxHealth = config.customStats?.maxHealth || calculatedStats.maxHealth;
+    const attack = config.customStats?.attack || calculatedStats.attack;
+    const defense = config.customStats?.defense || calculatedStats.defense;
+    const speed = config.customStats?.speed || calculatedStats.speed;
 
-    // Unitクラスのコンストラクタを呼び出し
+    // Unitのコンストラクタを最初に呼び出す
     super({
       scene: config.scene,
       x: config.x,
@@ -87,14 +88,14 @@ export class EnemyUnit extends Unit {
     // エネミー固有のプロパティを設定
     this.level = config.level;
 
+    // 基本ステータスの初期化（サブクラスでオーバーライド）
+    this.initializeBaseStats();
+
     // 経験値の初期化
     this.expValue = this.calculateExpValue();
 
     // ドロップアイテムの初期化
     this.initializeDrops();
-
-    // グラフィックス参照を取得
-    this.unitCircle = this.getAt(0) as Phaser.GameObjects.Graphics;
   }
 
   /**

--- a/src/objects/Unit.ts
+++ b/src/objects/Unit.ts
@@ -117,7 +117,8 @@ export class Unit extends Phaser.GameObjects.Container {
     this.nameText.setPosition(this.x, this.y - 60);
   }
 
-  protected updateCooldowns(delta: number): void { // privateからprotectedに変更
+  protected updateCooldowns(delta: number): void {
+    // privateからprotectedに変更
     // 攻撃クールダウン
     if (this.attackCooldown > 0) {
       this.attackCooldown -= delta;
@@ -137,7 +138,8 @@ export class Unit extends Phaser.GameObjects.Container {
     }
   }
 
-  protected updateMovement(delta: number): void { // privateからprotectedに変更
+  protected updateMovement(delta: number): void {
+    // privateからprotectedに変更
     // 移動クールダウン中は移動しない
     if (this.moveCooldown > 0) return;
 
@@ -178,7 +180,8 @@ export class Unit extends Phaser.GameObjects.Container {
     }
   }
 
-  protected updateDirection(angle: number): void { // privateからprotectedに変更
+  protected updateDirection(angle: number): void {
+    // privateからprotectedに変更
     // 方向インディケーターがない場合は何もしない
     if (!this.directionIndicator) return;
 
@@ -241,7 +244,8 @@ export class Unit extends Phaser.GameObjects.Container {
     }
   }
 
-  protected moveToRandomPositionNearTarget(): void { // privateからprotectedに変更
+  protected moveToRandomPositionNearTarget(): void {
+    // privateからprotectedに変更
     if (!this.target) return;
 
     // ターゲット周辺のランダムな位置

--- a/src/objects/Unit.ts
+++ b/src/objects/Unit.ts
@@ -28,9 +28,9 @@ export class Unit extends Phaser.GameObjects.Container {
   health: number;
   skillCooldown: number = 0;
   readonly skillMaxCooldown: number = 100;
-  private attackCooldown: number = 0;
+  protected attackCooldown: number = 0; // privateからprotectedに変更
   readonly attackCooldownMax: number = 1500; // ミリ秒
-  private moveCooldown: number = 0;
+  protected moveCooldown: number = 0; // privateからprotectedに変更
   readonly moveCooldownMax: number = 500; // ミリ秒
 
   // 戦闘報酬関連
@@ -41,8 +41,8 @@ export class Unit extends Phaser.GameObjects.Container {
   protected battleScene: BattleScene; // privateからprotectedに変更
 
   // 見た目関連
-  private unitCircle: Phaser.GameObjects.Graphics;
-  private directionIndicator: Phaser.GameObjects.Graphics;
+  protected unitCircle: Phaser.GameObjects.Graphics; // privateからprotectedに変更
+  protected directionIndicator: Phaser.GameObjects.Graphics; // privateからprotectedに変更
   hpText?: Phaser.GameObjects.Text;
   nameText: Phaser.GameObjects.Text;
 
@@ -117,7 +117,7 @@ export class Unit extends Phaser.GameObjects.Container {
     this.nameText.setPosition(this.x, this.y - 60);
   }
 
-  private updateCooldowns(delta: number): void {
+  protected updateCooldowns(delta: number): void { // privateからprotectedに変更
     // 攻撃クールダウン
     if (this.attackCooldown > 0) {
       this.attackCooldown -= delta;
@@ -137,8 +137,7 @@ export class Unit extends Phaser.GameObjects.Container {
     }
   }
 
-  protected updateMovement(delta: number): void {
-    // privateからprotectedに変更
+  protected updateMovement(delta: number): void { // privateからprotectedに変更
     // 移動クールダウン中は移動しない
     if (this.moveCooldown > 0) return;
 
@@ -179,8 +178,7 @@ export class Unit extends Phaser.GameObjects.Container {
     }
   }
 
-  protected updateDirection(angle: number): void {
-    // privateからprotectedに変更
+  protected updateDirection(angle: number): void { // privateからprotectedに変更
     // 方向インディケーターがない場合は何もしない
     if (!this.directionIndicator) return;
 
@@ -243,8 +241,7 @@ export class Unit extends Phaser.GameObjects.Container {
     }
   }
 
-  protected moveToRandomPositionNearTarget(): void {
-    // privateからprotectedに変更
+  protected moveToRandomPositionNearTarget(): void { // privateからprotectedに変更
     if (!this.target) return;
 
     // ターゲット周辺のランダムな位置


### PR DESCRIPTION
## 修正内容

エネミーシステム実装で発生したTypeScriptエラーを修正しました。

### 主な修正点

1. **Unit.tsの修正**
   - `unitCircle`プロパティをprivateからprotectedに変更
   - `attackCooldown`や`directionIndicator`などの他のプロパティもprotectedに変更
   - `updateCooldowns`メソッドもprotectedに変更

2. **EnemyUnit.tsの修正**
   - コンストラクタ内のsuper()呼び出し順序を修正（TypeScriptでは継承クラスのコンストラクタで最初にsuper()を呼び出す必要がある）
   - 基本ステータス初期化の順序を修正
   - 型エラーが発生していた箇所を修正

3. **SlimeEnemy.tsの修正**
   - readonlyプロパティ（speed）の直接変更をやめ、speedMultiplierを使う方式に変更
   - updateMovementメソッドをオーバーライドして速度倍率を適用

### エラー解消

- TS2415: Class 'EnemyUnit' incorrectly extends base class 'Unit'.  
  Property 'unitCircle' is private in type 'Unit' but not in type 'EnemyUnit'.
- TS2376: A 'super' call must be the first statement in the constructor
- TS17009: 'super' must be called before accessing 'this' in the constructor
- TS2540: Cannot assign to 'speed' because it is a read-only property.

これらのエラーが全て解消されました。