### PR TITLE
ESLintの設定を修正してv9のフラットコンフィグに対応

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,33 +1,32 @@
 // eslint.config.js
 const tseslint = require('@typescript-eslint/eslint-plugin');
 const tsparser = require('@typescript-eslint/parser');
-const prettierConfig = require('eslint-config-prettier');
 const prettierPlugin = require('eslint-plugin-prettier');
 
+// 設定を簡略化
 module.exports = [
   {
-    ignores: ['node_modules', 'dist', 'webpack.config.js']
+    // グローバル設定
+    ignores: ['node_modules/**', 'dist/**', 'webpack.config.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        // ブラウザとES2021のグローバル変数
+        window: 'readonly',
+        document: 'readonly',
+        navigator: 'readonly'
+      }
+    }
   },
+  // TypeScript ファイル用の設定
   {
-    files: ['**/*.{js,ts}'],
+    files: ['**/*.ts'],
     languageOptions: {
       parser: tsparser,
       parserOptions: {
-        ecmaVersion: 2021,
-        sourceType: 'module',
         project: './tsconfig.json'
-      },
-      // 環境設定を直接指定する
-      globals: {
-        // ブラウザのグローバル変数
-        window: 'readonly',
-        document: 'readonly',
-        navigator: 'readonly',
-        // ES2021のグローバル変数
-        Promise: 'readonly',
-        Map: 'readonly',
-        Set: 'readonly'
-      },
+      }
     },
     plugins: {
       '@typescript-eslint': tseslint,
@@ -39,16 +38,17 @@ module.exports = [
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       'no-console': ['warn', { allow: ['warn', 'error'] }]
-    },
-    // ESLint v9の環境設定方法
-    linterOptions: {
-      reportUnusedDisableDirectives: true,
-    },
-    // 環境設定
-    env: {
-      browser: true,
-      es2021: true
     }
   },
-  prettierConfig
+  // JavaScript ファイル用の設定
+  {
+    files: ['**/*.js'],
+    plugins: {
+      prettier: prettierPlugin
+    },
+    rules: {
+      'prettier/prettier': 'error',
+      'no-console': ['warn', { allow: ['warn', 'error'] }]
+    }
+  }
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,4 @@
 // eslint.config.js
-const eslint = require('eslint');
 const tseslint = require('@typescript-eslint/eslint-plugin');
 const tsparser = require('@typescript-eslint/parser');
 const prettierConfig = require('eslint-config-prettier');
@@ -18,9 +17,16 @@ module.exports = [
         sourceType: 'module',
         project: './tsconfig.json'
       },
+      // 環境設定を直接指定する
       globals: {
-        ...eslint.environments.browser,
-        ...eslint.environments.es2021
+        // ブラウザのグローバル変数
+        window: 'readonly',
+        document: 'readonly',
+        navigator: 'readonly',
+        // ES2021のグローバル変数
+        Promise: 'readonly',
+        Map: 'readonly',
+        Set: 'readonly'
       },
     },
     plugins: {
@@ -33,6 +39,15 @@ module.exports = [
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       'no-console': ['warn', { allow: ['warn', 'error'] }]
+    },
+    // ESLint v9の環境設定方法
+    linterOptions: {
+      reportUnusedDisableDirectives: true,
+    },
+    // 環境設定
+    env: {
+      browser: true,
+      es2021: true
     }
   },
   prettierConfig

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,18 +1,25 @@
 // eslint.config.js
+const js = require('@eslint/js');
 const tseslint = require('@typescript-eslint/eslint-plugin');
 const tsparser = require('@typescript-eslint/parser');
 const prettierPlugin = require('eslint-plugin-prettier');
+const prettierConfig = require('eslint-config-prettier');
 
-// 設定を簡略化
+// ESLint v9のフラットコンフィグスタイル
 module.exports = [
+  // グローバル設定
   {
-    // グローバル設定
-    ignores: ['node_modules/**', 'dist/**', 'webpack.config.js'],
+    ignores: ['node_modules/**', 'dist/**', 'webpack.config.js']
+  },
+  // ベースとなるJavaScriptの推奨設定
+  js.configs.recommended,
+  // 全ファイル共通設定
+  {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'module',
       globals: {
-        // ブラウザとES2021のグローバル変数
+        // ブラウザのグローバル変数
         window: 'readonly',
         document: 'readonly',
         navigator: 'readonly'
@@ -33,6 +40,7 @@ module.exports = [
       prettier: prettierPlugin
     },
     rules: {
+      ...tseslint.configs['recommended'].rules,
       'prettier/prettier': 'error',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
@@ -50,5 +58,7 @@ module.exports = [
       'prettier/prettier': 'error',
       'no-console': ['warn', { allow: ['warn', 'error'] }]
     }
-  }
+  },
+  // Prettierの競合設定を上書き
+  prettierConfig
 ];

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "phaser": "^3.60.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.21.0",
     "@typescript-eslint/eslint-plugin": "^8.26.0",
     "@typescript-eslint/parser": "^8.26.0",
     "copy-webpack-plugin": "^13.0.0",


### PR DESCRIPTION
## 修正内容

前回のPRでお見せした依存関係の更新で、eslint.config.jsファイルにエラーが発生したため、ESLint v9に対応した設定ファイルに修正しました。

```
TypeError: Cannot read properties of undefined (reading 'browser')
```

### 主な変更点

1. ESLint v9の新しいフラットコンフィグ形式に完全対応
2. `@eslint/js`パッケージを追加して推奨設定を利用
3. TypeScriptとJavaScriptで別々の設定を適用
4. グローバル変数の設定方法を修正

### テスト方法

1. このブランチをチェックアウト
2. `npm install`を実行して新しい依存関係をインストール
3. `npm run lint`を実行してエラーなく動作することを確認

ESLint v9は大きな変更があるため、この対応で正しく動作するようになります。
