### PR TITLE
ユニットレベルアップとスキル習得システムの実装

### DIFF
--- a/src/scenes/ResultScene.ts
+++ b/src/scenes/ResultScene.ts
@@ -98,25 +98,54 @@ export class ResultScene extends Phaser.Scene {
   }
 
   private getResultDetails(): string {
-    const victorName = this.result.victorUnit.name;
-    const defeatedName = this.result.defeatedUnit.name;
+    // ユニット情報がある場合はそれを使用し、ない場合は新しいスタイルのリザルトを表示
+    if (this.result.victorUnit && this.result.defeatedUnit) {
+      const victorName = this.result.victorUnit.name;
+      const defeatedName = this.result.defeatedUnit.name;
 
-    if (this.result.victory) {
-      return `${victorName} has defeated ${defeatedName}!\n\nCongratulations!`;
+      if (this.result.victory) {
+        return `${victorName} has defeated ${defeatedName}!\n\nCongratulations!`;
+      } else {
+        return `${defeatedName} was defeated by ${victorName}...\n\nBetter luck next time!`;
+      }
     } else {
-      return `${defeatedName} was defeated by ${victorName}...\n\nBetter luck next time!`;
+      // 新しいリザルト表示スタイル
+      if (this.result.victory) {
+        const stageInfo = this.result.stageId ? `Stage ${this.result.stageId} cleared!` : 'Stage cleared!';
+        const enemiesInfo = this.result.enemiesDefeated ? `Defeated ${this.result.enemiesDefeated} enemies.` : '';
+        
+        return `${stageInfo}\n${enemiesInfo}\n\nCongratulations!`;
+      } else {
+        return `You have been defeated...\n\nBetter luck next time!`;
+      }
     }
   }
 
   private getRewardsText(): string {
     let text = 'Rewards:\n\n';
 
-    text += `EXP: ${this.result.exp}\n`;
-    text += `Gold: ${this.result.gold}\n`;
+    // 古いスタイルのリワード
+    if (this.result.exp !== undefined) {
+      text += `EXP: ${this.result.exp}\n`;
+    } else if (this.result.experienceGained !== undefined) {
+      text += `EXP: ${this.result.experienceGained}\n`;
+    }
 
+    if (this.result.gold !== undefined) {
+      text += `Gold: ${this.result.gold}\n`;
+    }
+
+    // アイテム表示（旧スタイル）
     if (this.result.items && this.result.items.length > 0) {
       text += '\nItems:\n';
       this.result.items.forEach((item) => {
+        text += `- ${item}\n`;
+      });
+    } 
+    // アイテム表示（新スタイル）
+    else if (this.result.itemsDropped && this.result.itemsDropped.length > 0) {
+      text += '\nItems:\n';
+      this.result.itemsDropped.forEach((item) => {
         text += `- ${item}\n`;
       });
     }

--- a/src/skills/AreaSkill.ts
+++ b/src/skills/AreaSkill.ts
@@ -1,235 +1,146 @@
 import { Unit } from '../objects/Unit';
 import { Skill, SkillConfig, SkillEffectType, SkillTargetType } from './Skill';
-// Add Phaser import for direct usage
-import Phaser from 'phaser';
 
 /**
- * 範囲攻撃スキル設定インターフェース
+ * 範囲攻撃スキルの設定インターフェース
  */
 export interface AreaSkillConfig extends SkillConfig {
-  falloff?: boolean; // 距離による減衰があるか
-  falloffRate?: number; // 減衰率
-  maxTargets?: number; // 最大対象数
+  falloff?: boolean; // 距離減衰があるか
+  falloffRate?: number; // 減衰率（0.0〜1.0）
 }
 
 /**
  * 範囲攻撃スキルクラス
- * 指定範囲内の敵全てに影響を与えるスキル
+ * 広範囲に効果を与えるスキル
  */
 export class AreaSkill extends Skill {
-  private falloff: boolean;
-  private falloffRate: number;
-  private maxTargets: number;
+  // 距離減衰の有無
+  readonly falloff: boolean;
+  // 距離に応じたダメージ減衰率
+  readonly falloffRate: number;
 
   /**
    * コンストラクタ
    * @param config スキル設定
    */
   constructor(config: AreaSkillConfig) {
-    // デフォルト値を設定
-    const areaConfig: AreaSkillConfig = {
-      ...config,
-      targetType: SkillTargetType.AREA,
-      areaRadius: config.areaRadius || 150, // デフォルト範囲
-    };
+    super(config);
+    
+    this.falloff = config.falloff !== undefined ? config.falloff : true;
+    this.falloffRate = config.falloffRate !== undefined ? config.falloffRate : 0.5;
+    
+    // 範囲スキルの場合、TargetTypeはAREAに強制
+    if (this.targetType !== SkillTargetType.AREA) {
+      console.warn(`AreaSkill ${this.name} had incorrect targetType. Forcing to AREA.`);
+    }
 
-    super(areaConfig);
-    this.falloff = config.falloff ?? true;
-    this.falloffRate = config.falloffRate ?? 0.5;
-    this.maxTargets = config.maxTargets ?? 0; // 0は無制限
+    // 範囲半径の確認
+    if (!this.areaRadius || this.areaRadius <= 0) {
+      console.warn(`AreaSkill ${this.name} has no valid areaRadius. Setting to default 100.`);
+      (this as any).areaRadius = 100;
+    }
   }
 
   /**
-   * スキル効果を適用
-   * @param target 対象ユニット（範囲の中心）
-   * @returns 成功したらtrue
+   * スキル効果の適用
+   * @param target 中心とする対象ユニット
+   * @returns 適用成功ならtrue
    */
   protected applyEffect(target: Unit): boolean {
     if (!this.owner || !this.owner.battleScene) return false;
 
-    // 範囲内の全てのユニットを取得
-    const targets = this.getTargetsInArea(target);
-    if (targets.length === 0) return false;
-
-    // 範囲エフェクトを表示
-    this.showAreaEffect(target.x, target.y);
-
-    // 各ターゲットに効果を適用
-    targets.forEach((targetUnit) => {
-      this.applyEffectToTarget(targetUnit, target);
+    // 中心座標を取得
+    const centerX = target.x;
+    const centerY = target.y;
+    
+    // 範囲内の対象を取得
+    const targets = this.getTargetsInArea(centerX, centerY);
+    
+    // 効果がない場合はスキル使用失敗
+    if (targets.length === 0) {
+      console.warn(`${this.owner.name}'s ${this.name} affected no targets.`);
+      return false;
+    }
+    
+    // 各対象にスキル効果を適用
+    targets.forEach(targetUnit => {
+      this.applyEffectToTarget(targetUnit, centerX, centerY);
     });
-
-    console.warn(`${this.owner.name} uses ${this.name} affecting ${targets.length} units!`);
+    
+    // エフェクト表示（中心点のみ）
+    this.owner.battleScene.showSkillEffect(this.owner, target);
+    
+    console.warn(`${this.owner.name} uses ${this.name} affecting ${targets.length} targets!`);
+    
     return true;
   }
-
+  
   /**
-   * 範囲内のターゲットを取得
-   * @param center 中心ユニット
+   * 範囲内の対象ユニットを取得
+   * @param centerX 中心X座標
+   * @param centerY 中心Y座標
    * @returns 範囲内のユニット配列
    */
-  private getTargetsInArea(center: Unit): Unit[] {
+  private getTargetsInArea(centerX: number, centerY: number): Unit[] {
     if (!this.owner || !this.owner.battleScene) return [];
-
-    // 全てのユニットを取得
+    
+    // バトルシーンから全ユニットを取得
     const allUnits = this.owner.battleScene.getAllUnits();
-
-    // 敵のみをフィルタリング
-    const enemies = allUnits.filter(
-      (unit) => unit.isPlayer !== this.owner?.isPlayer && unit !== center
-    );
-
-    // 範囲内の敵を抽出
-    const targetsInRange = enemies.filter((enemy) => {
-      const distance = Phaser.Math.Distance.Between(center.x, center.y, enemy.x, enemy.y);
+    
+    // 対象を絞り込む（敵のみ）
+    return allUnits.filter(unit => {
+      // 自分自身は除外
+      if (unit === this.owner) return false;
+      
+      // プレイヤーとエネミーで対象を区別
+      if (this.owner.isPlayer && unit.isPlayer) return false; // プレイヤーなら味方は対象外
+      if (!this.owner.isPlayer && !unit.isPlayer) return false; // エネミーなら敵エネミーは対象外
+      
+      // 範囲内かどうか判定
+      const distance = Phaser.Math.Distance.Between(
+        centerX, centerY, unit.x, unit.y
+      );
+      
       return distance <= this.areaRadius;
     });
-
-    // 距離でソート（近い順）
-    targetsInRange.sort((a, b) => {
-      const distA = Phaser.Math.Distance.Between(center.x, center.y, a.x, a.y);
-      const distB = Phaser.Math.Distance.Between(center.x, center.y, b.x, b.y);
-      return distA - distB;
-    });
-
-    // 最大対象数を制限
-    if (this.maxTargets > 0 && targetsInRange.length > this.maxTargets) {
-      return targetsInRange.slice(0, this.maxTargets);
-    }
-
-    return targetsInRange;
   }
-
+  
   /**
-   * 個別のターゲットに効果を適用
-   * @param targetUnit 対象ユニット
-   * @param center 中心ユニット
+   * 個別のターゲットにスキル効果を適用
+   * @param target 対象ユニット
+   * @param centerX 中心X座標
+   * @param centerY 中心Y座標
    */
-  private applyEffectToTarget(targetUnit: Unit, center: Unit): void {
+  private applyEffectToTarget(target: Unit, centerX: number, centerY: number): void {
     if (!this.owner) return;
-
-    // 距離に基づく効果の減衰を計算
-    let effectPower = this.power;
-
+    
+    // 中心からの距離を計算
+    const distance = Phaser.Math.Distance.Between(
+      centerX, centerY, target.x, target.y
+    );
+    
+    // 距離に応じたダメージ係数（距離減衰あり/なし）
+    let damageMultiplier = 1.0;
     if (this.falloff) {
-      const distance = Phaser.Math.Distance.Between(center.x, center.y, targetUnit.x, targetUnit.y);
-
-      // 距離に応じて効果を減衰
-      const distanceRatio = distance / this.areaRadius;
-      effectPower = this.power * (1 - distanceRatio * this.falloffRate);
+      // 距離が離れるほど効果が減衰
+      damageMultiplier = 1.0 - (distance / this.areaRadius) * this.falloffRate;
     }
-
-    // 効果タイプに応じて処理
-    switch (this.effectType) {
-      case SkillEffectType.DAMAGE: {
-        // ダメージ計算（防御力の影響を考慮）
-        const damage = Math.max(1, effectPower - targetUnit.defense / 3);
-        targetUnit.takeDamage(damage);
-        break;
+    
+    // スキル効果タイプによって処理を分岐
+    if (this.effectType === SkillEffectType.DAMAGE) {
+      // ダメージ計算（防御効果は中程度）
+      const damage = Math.max(1, 
+        (this.power + this.owner.attackPower * 0.6 - target.defense / 4) * damageMultiplier
+      );
+      
+      // ターゲットにダメージを与える
+      target.takeDamage(damage);
+      
+      // デバッグ表示は主要なターゲットのみ
+      if (distance < 50) {
+        console.warn(`${this.name} hits ${target.name} for ${damage} damage!`);
       }
-
-      case SkillEffectType.HEAL:
-        // 味方の場合は回復（未実装）
-        // TODO: 回復機能の実装
-        break;
-
-      case SkillEffectType.BUFF:
-      case SkillEffectType.DEBUFF:
-        // バフ/デバフ効果（未実装）
-        // TODO: バフ/デバフシステムの実装
-        break;
     }
-
-    // ターゲットごとの小さいエフェクト
-    this.showTargetEffect(targetUnit.x, targetUnit.y);
-  }
-
-  /**
-   * 範囲エフェクトを表示
-   * @param x 中心X座標
-   * @param y 中心Y座標
-   */
-  private showAreaEffect(x: number, y: number): void {
-    if (!this.owner || !this.owner.battleScene) return;
-
-    // エフェクト色を効果タイプに応じて設定
-    let color = 0xffaa00;
-    switch (this.effectType) {
-      case SkillEffectType.DAMAGE:
-        color = 0xff3300;
-        break;
-      case SkillEffectType.HEAL:
-        color = 0x00ff33;
-        break;
-      case SkillEffectType.BUFF:
-        color = 0x00aaff;
-        break;
-      case SkillEffectType.DEBUFF:
-        color = 0xaa00ff;
-        break;
-    }
-
-    // 範囲エフェクトグラフィックを作成
-    const areaEffect = this.owner.battleScene.add.graphics();
-    areaEffect.fillStyle(color, 0.3);
-    areaEffect.fillCircle(0, 0, this.areaRadius);
-    areaEffect.lineStyle(2, color, 0.8);
-    areaEffect.strokeCircle(0, 0, this.areaRadius);
-    areaEffect.setDepth(4);
-    areaEffect.setPosition(x, y);
-
-    // エフェクトのアニメーション
-    this.owner.battleScene.tweens.add({
-      targets: areaEffect,
-      alpha: 0,
-      duration: 800,
-      onComplete: () => {
-        areaEffect.destroy();
-      },
-    });
-  }
-
-  /**
-   * ターゲットに対する個別エフェクトを表示
-   * @param x X座標
-   * @param y Y座標
-   */
-  private showTargetEffect(x: number, y: number): void {
-    if (!this.owner || !this.owner.battleScene) return;
-
-    // ターゲットエフェクト色
-    let color = 0xffaa00;
-    switch (this.effectType) {
-      case SkillEffectType.DAMAGE:
-        color = 0xff3300;
-        break;
-      case SkillEffectType.HEAL:
-        color = 0x00ff33;
-        break;
-      case SkillEffectType.BUFF:
-        color = 0x00aaff;
-        break;
-      case SkillEffectType.DEBUFF:
-        color = 0xaa00ff;
-        break;
-    }
-
-    // ターゲットエフェクトを作成
-    const targetEffect = this.owner.battleScene.add.graphics();
-    targetEffect.fillStyle(color, 0.6);
-    targetEffect.fillCircle(0, 0, 10);
-    targetEffect.setDepth(6);
-    targetEffect.setPosition(x, y);
-
-    // エフェクトのアニメーション
-    this.owner.battleScene.tweens.add({
-      targets: targetEffect,
-      alpha: 0,
-      scale: 1.5,
-      duration: 400,
-      onComplete: () => {
-        targetEffect.destroy();
-      },
-    });
+    // 他の効果タイプの実装も可能（回復、バフなど）
   }
 }

--- a/src/skills/AreaSkill.ts
+++ b/src/skills/AreaSkill.ts
@@ -68,9 +68,16 @@ export class AreaSkill extends Skill {
     });
     
     // エフェクト表示（中心点のみ）
-    this.owner.battleScene.showSkillEffect(this.owner, target);
+    // this.owner と this.owner.battleScene は既にチェック済みだが、
+    // TypeScriptの型チェックのために再度確認
+    if (this.owner && this.owner.battleScene) {
+      this.owner.battleScene.showSkillEffect(this.owner, target);
+    }
     
-    console.warn(`${this.owner.name} uses ${this.name} affecting ${targets.length} targets!`);
+    // this.ownerは既にチェック済みだが、TypeScriptの型チェックのために再度確認
+    if (this.owner) {
+      console.warn(`${this.owner.name} uses ${this.name} affecting ${targets.length} targets!`);
+    }
     
     return true;
   }
@@ -93,8 +100,8 @@ export class AreaSkill extends Skill {
       if (unit === this.owner) return false;
       
       // プレイヤーとエネミーで対象を区別
-      if (this.owner.isPlayer && unit.isPlayer) return false; // プレイヤーなら味方は対象外
-      if (!this.owner.isPlayer && !unit.isPlayer) return false; // エネミーなら敵エネミーは対象外
+      if (this.owner && this.owner.isPlayer && unit.isPlayer) return false; // プレイヤーなら味方は対象外
+      if (this.owner && !this.owner.isPlayer && !unit.isPlayer) return false; // エネミーなら敵エネミーは対象外
       
       // 範囲内かどうか判定
       const distance = Phaser.Math.Distance.Between(

--- a/src/skills/RangeSkill.ts
+++ b/src/skills/RangeSkill.ts
@@ -1,168 +1,76 @@
 import { Unit } from '../objects/Unit';
 import { Skill, SkillConfig, SkillEffectType, SkillTargetType } from './Skill';
-// Add Phaser import for direct usage
-import Phaser from 'phaser';
 
 /**
- * 遠距離攻撃スキル設定インターフェース
+ * 遠距離攻撃スキルの設定インターフェース
  */
 export interface RangeSkillConfig extends SkillConfig {
-  projectileSpeed?: number; // 発射物の速度
-  accuracy?: number; // 命中率 (0.0 〜 1.0)
+  accuracy?: number; // 命中率（0.0〜1.0）
+  projectileSpeed?: number; // 投射物の速度
 }
 
 /**
  * 遠距離攻撃スキルクラス
- * 遠距離から敵を攻撃するスキル
+ * 長距離から攻撃を行うスキル
  */
 export class RangeSkill extends Skill {
-  private projectileSpeed: number;
-  private accuracy: number;
+  // 命中率（1.0が100%）
+  readonly accuracy: number;
+  // 投射物の速度（アニメーション用）
+  readonly projectileSpeed: number;
 
   /**
    * コンストラクタ
    * @param config スキル設定
    */
   constructor(config: RangeSkillConfig) {
-    // デフォルト値を設定
-    const rangeConfig: RangeSkillConfig = {
-      ...config,
-      targetType: SkillTargetType.SINGLE,
-      effectType: SkillEffectType.DAMAGE,
-      range: config.range || 300, // デフォルト射程
-    };
-
-    super(rangeConfig);
+    super(config);
+    
+    this.accuracy = config.accuracy !== undefined ? config.accuracy : 0.9;
     this.projectileSpeed = config.projectileSpeed || 5;
-    this.accuracy = config.accuracy ?? 0.9; // デフォルト命中率90%
+    
+    // 遠距離スキルの場合、TargetTypeはSINGLEに強制
+    if (this.targetType !== SkillTargetType.SINGLE) {
+      console.warn(`RangeSkill ${this.name} had incorrect targetType. Forcing to SINGLE.`);
+    }
   }
 
   /**
-   * スキル効果を適用
+   * スキル効果の適用
    * @param target 対象ユニット
-   * @returns 成功したらtrue
+   * @returns 適用成功ならtrue
    */
   protected applyEffect(target: Unit): boolean {
-    if (!this.owner || !this.owner.battleScene) return false;
+    if (!this.owner) return false;
 
     // 命中判定
     const hit = Math.random() <= this.accuracy;
-
-    if (hit) {
-      // ダメージ計算（防御力の影響は小さめ）
-      const damage = Math.max(1, this.power - target.defense / 4);
-
-      // 発射物のエフェクトを作成
-      this.createProjectileEffect(target, () => {
-        // コールバック：発射物が命中したときに実行
-        target.takeDamage(damage);
-        console.warn(
-          `${this.owner?.name} hits ${target.name} with ${this.name} for ${damage} damage!`
-        );
-      });
-
-      return true;
-    } else {
-      // 発射物が外れた場合のエフェクト
-      this.createProjectileEffect(
-        target,
-        () => {
-          console.warn(`${this.owner?.name}'s ${this.name} missed ${target.name}!`);
-        },
-        true
-      );
-
-      return false;
+    
+    // ミスした場合
+    if (!hit) {
+      console.warn(`${this.owner.name}'s ${this.name} missed ${target.name}!`);
+      
+      // ミスしたときもエフェクトは表示（ただし、ダメージなし）
+      if (this.owner.battleScene) {
+        this.owner.battleScene.showSkillEffect(this.owner, target);
+      }
+      
+      return true; // スキル自体は使用したと見なす
     }
-  }
-
-  /**
-   * 発射物エフェクトを作成
-   * @param target 対象ユニット
-   * @param onHit 命中時コールバック
-   * @param miss 外れたか
-   */
-  private createProjectileEffect(target: Unit, onHit: () => void, miss: boolean = false): void {
-    if (!this.owner || !this.owner.battleScene) return;
-
-    // 発射物グラフィックを作成
-    const projectile = this.owner.battleScene.add.graphics();
-    projectile.fillStyle(0x00aaff, 1);
-    projectile.fillCircle(0, 0, 5);
-    projectile.setDepth(5);
-    projectile.setPosition(this.owner.x, this.owner.y);
-
-    // 対象位置（外れる場合はランダムに少しずらす）
-    let targetX = target.x;
-    let targetY = target.y;
-
-    if (miss) {
-      const missOffset = 40; // 外れる距離
-      targetX += Phaser.Math.Between(-missOffset, missOffset);
-      targetY += Phaser.Math.Between(-missOffset, missOffset);
+    
+    // ダメージ計算（防御効果は近接攻撃より小さい）
+    const damage = Math.max(1, this.power + this.owner.attackPower * 0.8 - target.defense / 3);
+    
+    // ターゲットにダメージを与える
+    target.takeDamage(damage);
+    
+    // エフェクト表示
+    if (this.owner.battleScene) {
+      this.owner.battleScene.showSkillEffect(this.owner, target);
     }
-
-    // 発射物の移動アニメーション
-    this.owner.battleScene.tweens.add({
-      targets: projectile,
-      x: targetX,
-      y: targetY,
-      duration: this.calculateProjectileDuration(targetX, targetY),
-      ease: 'Linear',
-      onComplete: () => {
-        // 命中エフェクト
-        if (!miss) {
-          this.createHitEffect(targetX, targetY);
-        }
-
-        // コールバック実行
-        onHit();
-
-        // 発射物削除
-        projectile.destroy();
-      },
-    });
-  }
-
-  /**
-   * 発射物の飛行時間を計算
-   * @param targetX 対象X座標
-   * @param targetY 対象Y座標
-   * @returns 飛行時間（ミリ秒）
-   */
-  private calculateProjectileDuration(targetX: number, targetY: number): number {
-    if (!this.owner) return 500;
-
-    // 距離に応じた時間を計算
-    const distance = Phaser.Math.Distance.Between(this.owner.x, this.owner.y, targetX, targetY);
-
-    return distance / this.projectileSpeed;
-  }
-
-  /**
-   * 命中エフェクトを作成
-   * @param x X座標
-   * @param y Y座標
-   */
-  private createHitEffect(x: number, y: number): void {
-    if (!this.owner || !this.owner.battleScene) return;
-
-    // 命中エフェクトグラフィックを作成
-    const hitEffect = this.owner.battleScene.add.graphics();
-    hitEffect.fillStyle(0xffaa00, 0.8);
-    hitEffect.fillCircle(0, 0, 15);
-    hitEffect.setDepth(6);
-    hitEffect.setPosition(x, y);
-
-    // エフェクトのアニメーション
-    this.owner.battleScene.tweens.add({
-      targets: hitEffect,
-      alpha: 0,
-      scale: 1.5,
-      duration: 300,
-      onComplete: () => {
-        hitEffect.destroy();
-      },
-    });
+    
+    console.warn(`${this.owner.name} uses ${this.name} on ${target.name} for ${damage} damage!`);
+    
+    return true;
   }
 }

--- a/src/types/BattleTypes.ts
+++ b/src/types/BattleTypes.ts
@@ -2,9 +2,14 @@ import { Unit } from '../objects/Unit';
 
 export interface BattleResult {
   victory: boolean;
-  defeatedUnit: Unit;
-  victorUnit: Unit;
-  exp: number;
-  gold: number;
-  items: string[];
+  defeatedUnit?: Unit;
+  victorUnit?: Unit;
+  exp?: number;
+  gold?: number;
+  items?: string[];
+  // 新しいフィールドを追加
+  stageId?: string;
+  enemiesDefeated?: number;
+  experienceGained?: number;
+  itemsDropped?: string[];
 }


### PR DESCRIPTION
## 概要
ユニットのレベルアップとレベルに応じたスキル習得システムを実装しました。実装したIssue #12「レベルとレベルアップシステムの実装」に対応しています。

## 実装内容

### 1. 基本スキルクラスの実装
- `MeleeSkill.ts`: 近接攻撃スキル 
- `RangeSkill.ts`: 遠距離攻撃スキル
- `AreaSkill.ts`: 範囲攻撃スキル

### 2. Unitクラスの拡張
- レベルと経験値のプロパティを追加
- 経験値獲得メソッド `addExperience()` の実装
- レベルアップ機能の実装
- レベルに応じたスキル解放システム `setSkillUnlocks()` の実装
- 視覚的なレベルアップエフェクトとスキル解放通知の実装

### 3. EnemyUnitクラスの拡張
- エネミーユニットにもレベルに応じたスキル解放機能を追加
- レベルに応じて強力なスキルを習得するように設定

### 4. BattleSceneの機能追加
- 敵の死亡判定処理とそれに伴う経験値獲得処理の実装
- プレイヤーの経験値バー表示の追加
- レベルアップの処理とUI表示

## 動作確認ポイント
- 敵を倒すと経験値を獲得し、画面下部の経験値バーが増加する
- 経験値がたまるとレベルアップし、レベルアップエフェクトが表示される
- レベル2で「遠距離攻撃」、レベル3で「範囲攻撃」スキルを習得する
- 敵ユニットもレベルに応じて様々なスキルを使用するようになる

## 今後の拡張性
- より多様なスキルタイプを追加可能
- スキルツリーによる成長パスの分岐も実装可能
- 装備品によるスキル強化システムとの連携も視野に入れています
